### PR TITLE
Remove reflection and upgrade libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,5 @@ pom.xml
 pom.xml.asc
 *.jar
 *.class
-.lein-deps-sum
-.lein-failures
-.lein-plugins
-.lein-repl-history
+/.lein-*
+/.nrepl-*

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,16 @@
-(defproject hystrix-event-stream-clj "0.1.3"
+(defproject hystrix-event-stream-clj "0.1.4-SNAPSHOT"
   :description "Generate hystrix event streams"
   :url "http://github.com/josephwilk/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.netflix.hystrix/hystrix-clj "1.3.1"]
-                 [com.netflix.hystrix/hystrix-metrics-event-stream "1.1.2"]
-                 [lamina "0.5.0-rc3"]
-                 [aleph "0.3.0-rc2"]
-                 [cheshire "5.2.0"]]
+                 [com.netflix.hystrix/hystrix-clj "1.3.20"]
+                 [com.netflix.hystrix/hystrix-metrics-event-stream "1.3.20"]
+                 [lamina "0.5.6"]
+                 [aleph "0.3.3"]
+                 [cheshire "5.4.0"]]
 
-  :profiles {:dev {:dependencies [[midje "1.5.1"]]
+  :profiles {:dev {:dependencies [[midje "1.6.3"]]
                    :plugins      [[lein-midje "3.0.1"]
                                   [lein-cloverage "1.0.2"]
                                   [lein-kibit "0.0.8"]]}})

--- a/src/hystrix_event_stream_clj/core.clj
+++ b/src/hystrix_event_stream_clj/core.clj
@@ -7,11 +7,15 @@
 
 (def default-delay 2000)
 
+(defn- enqueue-metrics [ch metrics]
+  (doseq [metric metrics]
+    (enqueue ch (str "\ndata: " (json/generate-string metric) "\n"))))
+
 (defn- write-metrics [ch]
   (try
     (enqueue ch (str "\nping: \n"))
-    (doall (map #(enqueue ch (str "\ndata: " (json/encode %) "\n")) (metrics/commands)))
-    (doall (map #(enqueue ch (str "\ndata: " (json/encode %) "\n")) (metrics/thread-pools)))
+    (enqueue-metrics ch (metrics/commands))
+    (enqueue-metrics ch (metrics/thread-pools))
     true
     (catch java.io.IOException e
       false)

--- a/src/hystrix_event_stream_clj/metrics.clj
+++ b/src/hystrix_event_stream_clj/metrics.clj
@@ -1,6 +1,6 @@
 (ns hystrix-event-stream-clj.metrics
   (:import [rx Observable Observer Subscription] rx.subscriptions.Subscriptions
-           [com.netflix.hystrix Hystrix HystrixExecutable HystrixCommandMetrics HystrixThreadPoolMetrics HystrixCircuitBreaker$Factory]
+           [com.netflix.hystrix Hystrix HystrixExecutable HystrixCommandMetrics HystrixThreadPoolMetrics HystrixCircuitBreaker$Factory HystrixCommandProperties]
            [com.netflix.hystrix.util HystrixRollingNumberEvent])
   (:require
    [aleph.http               :refer :all]
@@ -12,7 +12,7 @@
   (let [key (.getCommandKey cmd)
         circuit-breaker (HystrixCircuitBreaker$Factory/getInstance key)
         healthCounts (.getHealthCounts cmd)
-        cmd-properties (.getProperties cmd)]
+        ^HystrixCommandProperties cmd-properties (.getProperties cmd)]
     {:type "HystrixCommand"
      :name (.name key)
      :group (-> cmd .getCommandGroup .name)
@@ -61,46 +61,46 @@
                     "100" (.getTotalTimePercentile cmd 100)
                     }
 
-     :propertyValue_circuitBreakerRequestVolumeThreshold (-> cmd-properties .circuitBreakerRequestVolumeThreshold .get)
-     :propertyValue_circuitBreakerSleepWindowInMilliseconds (-> cmd-properties .circuitBreakerSleepWindowInMilliseconds .get)
-     :propertyValue_circuitBreakerErrorThresholdPercentage (-> cmd-properties .circuitBreakerErrorThresholdPercentage .get)
-     :propertyValue_circuitBreakerForceOpen (-> cmd-properties .circuitBreakerForceOpen .get)
-     :propertyValue_circuitBreakerForceClosed (-> cmd-properties .circuitBreakerForceClosed .get)
-     :propertyValue_circuitBreakerEnabled (-> cmd-properties .circuitBreakerEnabled .get)
+     :propertyValue_circuitBreakerRequestVolumeThreshold (.. cmd-properties circuitBreakerRequestVolumeThreshold get)
+     :propertyValue_circuitBreakerSleepWindowInMilliseconds (.. cmd-properties circuitBreakerSleepWindowInMilliseconds get)
+     :propertyValue_circuitBreakerErrorThresholdPercentage (.. cmd-properties circuitBreakerErrorThresholdPercentage get)
+     :propertyValue_circuitBreakerForceOpen (.. cmd-properties circuitBreakerForceOpen get)
+     :propertyValue_circuitBreakerForceClosed (.. cmd-properties circuitBreakerForceClosed get)
+     :propertyValue_circuitBreakerEnabled (.. cmd-properties circuitBreakerEnabled get)
 
-     :propertyValue_executionIsolationStrategy (-> cmd-properties .executionIsolationStrategy .get .name)
-     :propertyValue_executionIsolationThreadTimeoutInMilliseconds (-> cmd-properties .executionIsolationThreadTimeoutInMilliseconds .get)
-     :propertyValue_executionIsolationThreadInterruptOnTimeout (-> cmd-properties .executionIsolationThreadInterruptOnTimeout .get)
-     :propertyValue_executionIsolationThreadPoolKeyOverride (-> cmd-properties .executionIsolationThreadPoolKeyOverride .get)
-     :propertyValue_executionIsolationSemaphoreMaxConcurrentRequests (-> cmd-properties .executionIsolationSemaphoreMaxConcurrentRequests .get)
-     :propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests (-> cmd-properties .fallbackIsolationSemaphoreMaxConcurrentRequests .get )
+     :propertyValue_executionIsolationStrategy (.. cmd-properties executionIsolationStrategy get toString)
+     :propertyValue_executionIsolationThreadTimeoutInMilliseconds (.. cmd-properties executionIsolationThreadTimeoutInMilliseconds get)
+     :propertyValue_executionIsolationThreadInterruptOnTimeout (.. cmd-properties executionIsolationThreadInterruptOnTimeout get)
+     :propertyValue_executionIsolationThreadPoolKeyOverride (.. cmd-properties executionIsolationThreadPoolKeyOverride get)
+     :propertyValue_executionIsolationSemaphoreMaxConcurrentRequests (.. cmd-properties executionIsolationSemaphoreMaxConcurrentRequests get)
+     :propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests (.. cmd-properties fallbackIsolationSemaphoreMaxConcurrentRequests get )
 
-     :propertyValue_metricsRollingStatisticalWindowInMilliseconds (-> cmd-properties .metricsRollingStatisticalWindowInMilliseconds .get)
-     :propertyValue_requestCacheEnabled, (-> cmd-properties .requestCacheEnabled .get)
-     :propertyValue_requestLogEnabled, (-> cmd-properties .requestLogEnabled .get)
+     :propertyValue_metricsRollingStatisticalWindowInMilliseconds (.. cmd-properties metricsRollingStatisticalWindowInMilliseconds get)
+     :propertyValue_requestCacheEnabled, (.. cmd-properties requestCacheEnabled get)
+     :propertyValue_requestLogEnabled, (.. cmd-properties requestLogEnabled get)
 
      :reportingHosts 1}))
 
-(defn- thread-pool->metric [pool]
+(defn- thread-pool->metric [^HystrixThreadPoolMetrics pool]
   (let [key (.getThreadPoolKey pool)]
 
     {:type, "HystrixThreadPool"
      :name, (.name key)
      :currentTime, (System/currentTimeMillis)
 
-     :currentActiveCount (-> pool .getCurrentActiveCount .intValue)
-     :currentCompletedTaskCount (-> pool .getCurrentCompletedTaskCount .longValue)
-     :currentCorePoolSize (-> pool .getCurrentCorePoolSize .intValue)
-     :currentLargestPoolSize (-> pool .getCurrentLargestPoolSize .intValue)
-     :currentMaximumPoolSize (-> pool .getCurrentMaximumPoolSize .intValue)
-     :currentPoolSize (-> pool .getCurrentPoolSize .intValue)
-     :currentQueueSize (-> pool .getCurrentQueueSize .intValue)
-     :currentTaskCount (-> pool .getCurrentTaskCount .longValue)
-     :rollingCountThreadsExecuted (-> pool .getRollingCountThreadsExecuted)
-     :rollingMaxActiveThreads (-> pool .getRollingMaxActiveThreads)
+     :currentActiveCount (.. pool getCurrentActiveCount intValue)
+     :currentCompletedTaskCount (.. pool getCurrentCompletedTaskCount longValue)
+     :currentCorePoolSize (.. pool getCurrentCorePoolSize intValue)
+     :currentLargestPoolSize (.. pool getCurrentLargestPoolSize intValue)
+     :currentMaximumPoolSize (.. pool getCurrentMaximumPoolSize intValue)
+     :currentPoolSize (.. pool getCurrentPoolSize intValue)
+     :currentQueueSize (.. pool getCurrentQueueSize intValue)
+     :currentTaskCount (.. pool getCurrentTaskCount longValue)
+     :rollingCountThreadsExecuted (.. pool getRollingCountThreadsExecuted)
+     :rollingMaxActiveThreads (.. pool getRollingMaxActiveThreads)
 
-     :propertyValue_queueSizeRejectionThreshold (-> pool .getProperties .queueSizeRejectionThreshold .get)
-     :propertyValue_metricsRollingStatisticalWindowInMilliseconds (-> pool .getProperties .metricsRollingStatisticalWindowInMilliseconds .get)
+     :propertyValue_queueSizeRejectionThreshold (.. pool getProperties queueSizeRejectionThreshold get)
+     :propertyValue_metricsRollingStatisticalWindowInMilliseconds (.. pool getProperties metricsRollingStatisticalWindowInMilliseconds get)
 
      :reportingHosts 1}))
 

--- a/test/hystrix_event_stream_clj/t_metrics.clj
+++ b/test/hystrix_event_stream_clj/t_metrics.clj
@@ -17,7 +17,7 @@
     (hystrix/execute #'testy)
     (let [data (metrics/commands)]
       (count data) => 1
-      (-> data first :name) => "testy"
+      (-> data first :name) => "hystrix-event-stream-clj.t-metrics/testy"
       (-> data first :type) => "HystrixCommand"))
 
   (fact "it returns thread pool metrics"


### PR DESCRIPTION
There was quite a lot of reflection going on in the metrics namespace. This change clears those up.
We were also a few versions behind in our dependencies.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/josephwilk/hystrix-event-stream-clj/2)

<!-- Reviewable:end -->
